### PR TITLE
Autodetect secret key from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ $snapAuth = new Client(secretKey: $yourSecret);
 > Secret keys are specific to an environment and domain.
 > We HIGHLY RECOMMEND using environment variables or another external storage mechanism.
 > Avoid committing them to version control, as this can more easily lead to compromise.
+>
+> The SDK will auto-detect the `SNAPAUTH_SECRET_KEY` environment variable if you do not provide a value directly.
 
 ## Usage
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -44,9 +44,17 @@ class Client
     private const DEFAULT_API_HOST = 'https://api.snapauth.app';
 
     public function __construct(
-        #[SensitiveParameter] private string $secretKey,
+        #[SensitiveParameter] private ?string $secretKey = null,
         private string $apiHost = self::DEFAULT_API_HOST,
     ) {
+        // Auto-detect if not provided
+        if ($secretKey === null) {
+            $env = getenv('SNAPAUTH_SECRET_KEY');
+            if ($env === false) {
+                throw new ApiError('Secret key missing. It can be explictly provided, or will be auto-detected from the SNAPAUTH_SECRET_KEY environment variable.');
+            }
+            $secretKey = $env;
+        }
         if (!str_starts_with($secretKey, 'secret_')) {
             throw new ApiError(
                 'Invalid secret key. Please verify you copied the full value from the SnapAuth dashboard.',

--- a/src/Client.php
+++ b/src/Client.php
@@ -43,8 +43,10 @@ class Client
 {
     private const DEFAULT_API_HOST = 'https://api.snapauth.app';
 
+    private string $secretKey;
+
     public function __construct(
-        #[SensitiveParameter] private ?string $secretKey = null,
+        #[SensitiveParameter] ?string $secretKey = null,
         private string $apiHost = self::DEFAULT_API_HOST,
     ) {
         // Auto-detect if not provided
@@ -60,6 +62,8 @@ class Client
                 'Invalid secret key. Please verify you copied the full value from the SnapAuth dashboard.',
             );
         }
+
+        $this->secretKey = $secretKey;
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -53,7 +53,11 @@ class Client
         if ($secretKey === null) {
             $env = getenv('SNAPAUTH_SECRET_KEY');
             if ($env === false) {
-                throw new ApiError('Secret key missing. It can be explictly provided, or will be auto-detected from the SNAPAUTH_SECRET_KEY environment variable.');
+                throw new ApiError(
+                    'Secret key missing. It can be explictly provided, or it ' .
+                    'can be auto-detected from the SNAPAUTH_SECRET_KEY ' .
+                    'environment variable.',
+                );
             }
             $secretKey = $env;
         }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -19,6 +19,15 @@ class ClientTest extends TestCase
         self::assertInstanceOf(Client::class, $client);
     }
 
+    public function testConstructSecretKeyAutodetectInvalid(): void
+    {
+        assert(getenv('SNAPAUTH_SECRET_KEY') === false);
+        putenv('SNAPAUTH_SECRET_KEY=invalid');
+        self::expectException(ApiError::class);
+        self::expectExceptionMessage('Invalid secret key.');
+        new Client();
+    }
+
     public function testConstructSecretKeyAutodetectMissing(): void
     {
         assert(getenv('SNAPAUTH_SECRET_KEY') === false);
@@ -38,5 +47,11 @@ class ClientTest extends TestCase
         $client = new Client(secretKey: 'secret_abc_123');
         $result = print_r($client, true);
         self::assertStringNotContainsString('secret_abc_123', $result);
+    }
+
+    public function tearDown(): void
+    {
+        // Note: trailing = sets it to empty string. This actually clears it.
+        putenv('SNAPAUTH_SECRET_KEY');
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -19,6 +19,14 @@ class ClientTest extends TestCase
         self::assertInstanceOf(Client::class, $client);
     }
 
+    public function testConstructSecretKeyAutodetectMissing(): void
+    {
+        assert(getenv('SNAPAUTH_SECRET_KEY') === false);
+        self::expectException(ApiError::class);
+        self::expectExceptionMessage('Secret key missing.');
+        new Client();
+    }
+
     public function testSecretKeyValidation(): void
     {
         self::expectException(ApiError::class);


### PR DESCRIPTION
Allow `new \SnapAuth\Client()` for even simpler setup, which will try to read from `SNAPAUTH_SECRET_KEY`.