### PR TITLE
Correct the type information for registration attach

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -70,14 +70,6 @@ class Client
         $this->secretKey = $secretKey;
     }
 
-    /**
-     * return array{
-     *   user: array{
-     *     id: string,
-     *     handle: string,
-     *   },
-     * }
-     */
     public function verifyAuthToken(string $authToken): AuthResponse
     {
         return $this->makeApiCall(
@@ -91,8 +83,8 @@ class Client
 
     /**
      * @param array{
-     *   handle: string,
-     *   id?: string,
+     *   handle?: string,
+     *   id: string,
      * } $user
      */
     public function attachRegistration(string $regToken, array $user): AttachResponse


### PR DESCRIPTION
The logic here is unchanged, but docblock type information for the input array was not. It's the `id` field that's required, not `handle`.

Also removes an extraneous comment that's outdated.