### PR TITLE
Update to latest response formats

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -87,7 +87,7 @@ class Client
      *   id: string,
      * } $user
      */
-    public function attachRegistration(string $regToken, array $user): AttachResponse
+    public function attachRegistration(string $regToken, array $user): Credential
     {
         return $this->makeApiCall(
             route: '/registration/attach',
@@ -95,7 +95,7 @@ class Client
                 'token' => $regToken,
                 'user' => $user,
             ],
-            type: AttachResponse::class
+            type: Credential::class
         );
     }
 

--- a/src/Credential.php
+++ b/src/Credential.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace SnapAuth;
 
-class AttachResponse
+class Credential
 {
+    public readonly string $id;
+
     // @phpstan-ignore-next-line
     public function __construct(array $data)
     {
-        // Intentionally empty for now - response format uncertain
+        $this->id = $data['id'];
     }
 }

--- a/src/User.php
+++ b/src/User.php
@@ -7,12 +7,10 @@ namespace SnapAuth;
 class User
 {
     public readonly string $id;
-    public readonly string $handle;
 
     // @phpstan-ignore-next-line
     public function __construct(array $data)
     {
         $this->id = $data['id'];
-        $this->handle = $data['handle'];
     }
 }


### PR DESCRIPTION
This adjusts the response format of two core API responses:

- `/registration/attach` response is renamed to `Credential`, which will be better reflected as other Credential management APIs get added
- The `handle` field has been removed from the `User` in the auth response. This matches https://github.com/snapauthapp/api-docs/pull/17 to support https://github.com/snapauthapp/api/issues/450