### PR TITLE
Update credential creation route

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -90,7 +90,7 @@ class Client
     public function attachRegistration(string $regToken, array $user): Credential
     {
         return $this->makeApiCall(
-            route: '/registration/attach',
+            route: '/credential/create',
             data: [
                 'token' => $regToken,
                 'user' => $user,


### PR DESCRIPTION
While the old endpoint will continue to work indefinitely, the credential creation API is being renamed and centralized to support upcoming functionality.