### PR TITLE
Convert Poser badges to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the official PHP SDK for [SnapAuth](https://www.snapauth.app).
 
 [![Latest Stable Version](https://poser.pugx.org/snapauth/sdk/v)](https://packagist.org/packages/snapauth/sdk)
 [![PHP Version Require](https://poser.pugx.org/snapauth/sdk/require/php)](https://packagist.org/packages/snapauth/sdk)
-[![License](httsp://poser.pugx.org/snapauth/sdk/license)](https://packagist.org/packages/snapauth/sdk)
+[![License](https://poser.pugx.org/snapauth/sdk/license)](https://packagist.org/packages/snapauth/sdk)
 
 [![Test](https://github.com/snapauthapp/sdk-php/actions/workflows/test.yml/badge.svg)](https://github.com/snapauthapp/sdk-php/actions/workflows/test.yml)
 [![Lint](https://github.com/snapauthapp/sdk-php/actions/workflows/lint.yml/badge.svg)](https://github.com/snapauthapp/sdk-php/actions/workflows/lint.yml)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This is the official PHP SDK for [SnapAuth](https://www.snapauth.app).
 
-[![Latest Stable Version](http://poser.pugx.org/snapauth/sdk/v)](https://packagist.org/packages/snapauth/sdk)
-[![PHP Version Require](http://poser.pugx.org/snapauth/sdk/require/php)](https://packagist.org/packages/snapauth/sdk)
-[![License](http://poser.pugx.org/snapauth/sdk/license)](https://packagist.org/packages/snapauth/sdk)
+[![Latest Stable Version](https://poser.pugx.org/snapauth/sdk/v)](https://packagist.org/packages/snapauth/sdk)
+[![PHP Version Require](https://poser.pugx.org/snapauth/sdk/require/php)](https://packagist.org/packages/snapauth/sdk)
+[![License](httsp://poser.pugx.org/snapauth/sdk/license)](https://packagist.org/packages/snapauth/sdk)
 
 [![Test](https://github.com/snapauthapp/sdk-php/actions/workflows/test.yml/badge.svg)](https://github.com/snapauthapp/sdk-php/actions/workflows/test.yml)
 [![Lint](https://github.com/snapauthapp/sdk-php/actions/workflows/lint.yml/badge.svg)](https://github.com/snapauthapp/sdk-php/actions/workflows/lint.yml)


### PR DESCRIPTION
These always should have been done this way, but the premade links had `http`, and it seems Github's readme renderer has stopped supporting this.