### PR TITLE
Remove library conflict warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,9 +37,6 @@
         "phpunit/phpunit": "^10.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
-    "conflict": {
-        "nikic/php-parser": "<v4.12"
-    },
     "scripts": {
         "test": [
             "@phpunit",


### PR DESCRIPTION
There was a library conflict indicator in place from the project template that doesn't apply to the SDK, so it's being removed.